### PR TITLE
fix: fix invalid test data

### DIFF
--- a/lib/resource_generator.rb
+++ b/lib/resource_generator.rb
@@ -206,7 +206,7 @@ module Crucible
           resource.subject.display = 'Patient'
         end
         resource.code = minimal_codeableconcept(system,code, namespace)
-        resource.verificationStatus = 'confirmed'
+        resource.verificationStatus = minimal_codeableconcept('http://terminology.hl7.org/CodeSystem/condition-ver-status', 'confirmed')
         tag_metadata(resource)
       end
 
@@ -678,7 +678,7 @@ module Crucible
             p.searchType = nil unless p.type == 'string'
           end
         when FHIR::Patient
-          resource.maritalStatus = minimal_codeableconcept('http://hl7.org/fhir/v3/MaritalStatus','S')
+          resource.maritalStatus = minimal_codeableconcept('http://terminology.hl7.org/CodeSystem/v3-MaritalStatus','S')
         when FHIR::PlanDefinition
           resource.action.each do |a|
             a.action.each do |b|
@@ -1463,7 +1463,7 @@ module Crucible
             p.searchType = nil unless p.type == 'string'
           end
         when FHIR::STU3::Patient
-          resource.maritalStatus = minimal_codeableconcept('http://hl7.org/fhir/v3/MaritalStatus','S', FHIR::STU3)
+          resource.maritalStatus = minimal_codeableconcept('http://terminology.hl7.org/CodeSystem/v3-MaritalStatus','S', FHIR::STU3)
         when FHIR::STU3::PlanDefinition
           resource.action.each do |a|
             a.action.each do |b|
@@ -2070,7 +2070,7 @@ module Crucible
         when FHIR::DSTU2::Order
           resource.when.schedule = nil
         when FHIR::DSTU2::Patient
-          resource.maritalStatus = minimal_codeableconcept('http://hl7.org/fhir/v3/MaritalStatus','S', FHIR::DSTU2)
+          resource.maritalStatus = minimal_codeableconcept('http://terminology.hl7.org/CodeSystem/v3-MaritalStatus','S', FHIR::DSTU2)
           resource.communication.each do |communication|
             communication.language.coding.each do |c|
               c.system = 'http://tools.ietf.org/html/bcp47'

--- a/lib/tests/suites/transaction_test.rb
+++ b/lib/tests/suites/transaction_test.rb
@@ -177,8 +177,8 @@ module Crucible
         @obs2 = ResourceGenerator.minimal_observation('http://loinc.org','3141-9',100,'kg',@patient0.id)
         # obesity has been refuted
         @condition0.subject.reference = "Patient/#{@patient0.id}"
-        @condition0.clinicalStatus = 'resolved'
-        @condition0.verificationStatus = 'refuted'
+        @condition0.clinicalStatus = ResourceGenerator.minimal_codeableconcept('http://terminology.hl7.org/CodeSystem/condition-clinical','resolved')
+        @condition0.verificationStatus = ResourceGenerator.minimal_codeableconcept('http://terminology.hl7.org/CodeSystem/condition-ver-status','refuted')
         @condition0.abatementString = 'Abated at unknown date'
 
         @client.begin_transaction


### PR DESCRIPTION
Some test data was invalid and was causing errors now that we have stronger validation.
Some fields were plain strings instead of proper CodeableConcepts. Some fields were using the wrong CodeSystem

Ran tests locally against fwoa and all passed after this changes